### PR TITLE
Emergency Role in Rover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "mars-rover",
  "mars-swapper-mock",
  "mars-zapper-mock",
+ "semver",
 ]
 
 [[package]]
@@ -1105,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "mars-owner"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5644a8b047a0d64d04706414805872f35439755e057431152dd36e6f369be24"
+checksum = "8ca010da465b4a5ea7274f59132d22b7c10765295c73d5744add2c1fea6c5e38"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1613,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ itertools         = "0.10.5"
 osmosis-std       = "0.14.0"
 osmosis-test-tube = "14.1.1"
 schemars          = "0.8.11"
+semver            = "1.0.17"
 serde             = { version = "1.0.152", default-features = false, features = ["derive"] }
 thiserror         = "1.0.38"
 
@@ -52,7 +53,7 @@ cw-vault-standard   = { version = "0.2.0", features = ["lockup", "force-unlock"]
 mars-health         = { version = "1.0.0", path = "./packages/health" }
 mars-osmosis        = { git = "https://github.com/mars-protocol/red-bank", rev = "d2a4b12f21344f1b572c0b2f75da585a4d2cc003" }
 mars-red-bank-types = "1.0.0"
-mars-owner          = "1.0.0"
+mars-owner          = { version = "1.1.0", features = ["emergency-owner"] }
 mars-rover          = { version = "1.0.0", path = "./packages/rover" }
 
 # contracts

--- a/contracts/credit-manager/Cargo.toml
+++ b/contracts/credit-manager/Cargo.toml
@@ -31,6 +31,7 @@ mars-health         = { workspace = true }
 mars-red-bank-types = { workspace = true }
 mars-owner          = { workspace = true }
 mars-rover          = { workspace = true }
+semver              = { workspace = true }
 
 [dev-dependencies]
 anyhow             = { workspace = true }

--- a/contracts/credit-manager/src/contract.rs
+++ b/contracts/credit-manager/src/contract.rs
@@ -1,15 +1,18 @@
 use cosmwasm_std::{
-    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    entry_point, to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response,
+    StdError,
 };
-use cw2::set_contract_version;
+use cw2::{get_contract_version, set_contract_version, ContractVersion};
 use mars_health::HealthResponse;
 use mars_rover::{
     adapters::vault::VAULT_REQUEST_REPLY_ID,
-    error::{ContractError, ContractResult},
+    error::{ContractError, ContractError::Migration, ContractResult},
     msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
 };
+use semver::Version;
 
 use crate::{
+    emergency_update::emergency_config_update,
     execute::{create_credit_account, dispatch_actions, execute_callback},
     health::compute_health,
     instantiate::store_config,
@@ -60,6 +63,7 @@ pub fn execute(
             account_id,
             actions,
         } => dispatch_actions(deps, env, info, &account_id, &actions),
+        ExecuteMsg::EmergencyConfigUpdate(update) => emergency_config_update(deps, info, update),
     }
 }
 
@@ -127,4 +131,34 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         } => to_binary(&estimate_withdraw_liquidity(deps, lp_token)?),
     };
     res.map_err(Into::into)
+}
+
+#[entry_point]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> ContractResult<Response> {
+    let ContractVersion {
+        contract: storage_contract,
+        version,
+    } = get_contract_version(deps.storage)?;
+
+    if storage_contract != CONTRACT_NAME {
+        return Err(Migration("Can only upgrade from same type".to_string()));
+    }
+
+    let storage_version = version
+        .parse::<Version>()
+        .map_err(|_| StdError::generic_err("storage version parse err"))?;
+    let new_version = CONTRACT_VERSION
+        .parse::<Version>()
+        .map_err(|_| StdError::generic_err("new version parse err"))?;
+
+    if storage_version >= new_version {
+        return Err(Migration("Cannot upgrade from a newer version".to_string()));
+    }
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute("from_version", version)
+        .add_attribute("to_version", CONTRACT_VERSION))
 }

--- a/contracts/credit-manager/src/emergency_update.rs
+++ b/contracts/credit-manager/src/emergency_update.rs
@@ -1,0 +1,57 @@
+use cosmwasm_std::{Decimal, DepsMut, MessageInfo, Response, Uint128};
+use mars_rover::{
+    adapters::vault::VaultUnchecked,
+    error::{ContractError::InvalidConfig, ContractResult},
+    msg::execute::EmergencyUpdate,
+};
+
+use crate::state::{ALLOWED_COINS, OWNER, VAULT_CONFIGS};
+
+pub fn emergency_config_update(
+    deps: DepsMut,
+    info: MessageInfo,
+    update: EmergencyUpdate,
+) -> ContractResult<Response> {
+    OWNER.assert_emergency_owner(deps.storage, &info.sender)?;
+
+    match update {
+        EmergencyUpdate::SetZeroMaxLtv(v) => set_zero_max_ltv(deps, v),
+        EmergencyUpdate::SetZeroDepositCap(v) => set_zero_deposit_cap(deps, v),
+        EmergencyUpdate::DisallowCoin(denom) => disallow_coin(deps, &denom),
+    }
+}
+
+pub fn set_zero_max_ltv(deps: DepsMut, v: VaultUnchecked) -> ContractResult<Response> {
+    let vault = deps.api.addr_validate(&v.address)?;
+    let mut config = VAULT_CONFIGS.load(deps.storage, &vault)?;
+    config.max_ltv = Decimal::zero();
+    VAULT_CONFIGS.save(deps.storage, &vault, &config)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "set_zero_max_ltv")
+        .add_attribute("vault", v.address))
+}
+
+pub fn set_zero_deposit_cap(deps: DepsMut, v: VaultUnchecked) -> ContractResult<Response> {
+    let vault = deps.api.addr_validate(&v.address)?;
+    let mut config = VAULT_CONFIGS.load(deps.storage, &vault)?;
+    config.deposit_cap.amount = Uint128::zero();
+    VAULT_CONFIGS.save(deps.storage, &vault, &config)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "set_zero_deposit_cap")
+        .add_attribute("vault", v.address))
+}
+
+pub fn disallow_coin(deps: DepsMut, denom: &str) -> ContractResult<Response> {
+    let result = ALLOWED_COINS.remove(deps.storage, denom)?;
+    if !result {
+        return Err(InvalidConfig {
+            reason: format!("{denom} not in config"),
+        });
+    }
+
+    Ok(Response::new()
+        .add_attribute("action", "disallow_coin")
+        .add_attribute("denom", denom.to_string()))
+}

--- a/contracts/credit-manager/src/lib.rs
+++ b/contracts/credit-manager/src/lib.rs
@@ -2,6 +2,7 @@ pub mod contract;
 
 pub mod borrow;
 pub mod deposit;
+pub mod emergency_update;
 pub mod execute;
 pub mod health;
 pub mod instantiate;

--- a/contracts/credit-manager/tests/helpers/mock_entity_info.rs
+++ b/contracts/credit-manager/tests/helpers/mock_entity_info.rs
@@ -51,9 +51,15 @@ pub fn unlocked_vault_info() -> VaultTestInfo {
 }
 
 pub fn generate_mock_vault(lockup: Option<Duration>) -> VaultTestInfo {
+    let vault_token_denom = if lockup.is_some() {
+        "uleverage-locked".to_string()
+    } else {
+        "uleverage-unlocked".to_string()
+    };
+
     let lp_token = lp_token_info();
     VaultTestInfo {
-        vault_token_denom: "uleverage".to_string(),
+        vault_token_denom,
         lockup,
         base_token_denom: lp_token.denom,
         deposit_cap: coin(10_000_000, "uusdc"),

--- a/contracts/credit-manager/tests/test_emergency_powers.rs
+++ b/contracts/credit-manager/tests/test_emergency_powers.rs
@@ -1,0 +1,174 @@
+use cosmwasm_std::{Addr, StdError::NotFound};
+use mars_owner::OwnerError::NotEmergencyOwner;
+use mars_rover::{
+    adapters::vault::VaultUnchecked,
+    error::ContractError::{InvalidConfig, Owner, Std},
+    msg::execute::EmergencyUpdate,
+};
+
+use crate::helpers::{
+    assert_err, locked_vault_info, uatom_info, unlocked_vault_info, uosmo_info, MockEnv,
+};
+
+pub mod helpers;
+
+#[test]
+fn only_emergency_owner_can_invoke_emergency_powers() {
+    let emergency_owner = Addr::unchecked("miles_morales");
+    let mut mock = MockEnv::new().emergency_owner(&emergency_owner).build().unwrap();
+    let bad_guy = Addr::unchecked("bad_guy");
+    let res = mock.emergency_update(&bad_guy, EmergencyUpdate::DisallowCoin("uosmo".to_string()));
+    assert_err(res, Owner(NotEmergencyOwner {}))
+}
+
+#[test]
+fn not_callable_if_no_emergency_role_set() {
+    let mut mock = MockEnv::new().build().unwrap();
+    let bad_guy = Addr::unchecked("bad_guy");
+    let res = mock.emergency_update(&bad_guy, EmergencyUpdate::DisallowCoin("uosmo".to_string()));
+    assert_err(res, Owner(NotEmergencyOwner {}))
+}
+
+#[test]
+fn emergency_owner_can_blacklist_coins() {
+    let emergency_owner = Addr::unchecked("miles_morales");
+    let osmo_info = uosmo_info();
+    let atom_info = uatom_info();
+
+    let mut mock = MockEnv::new()
+        .emergency_owner(&emergency_owner)
+        .allowed_coins(&[osmo_info.clone(), atom_info.clone()])
+        .build()
+        .unwrap();
+
+    let allowed_coins_before = mock.query_allowed_coins(None, None);
+    assert_eq!(allowed_coins_before.len(), 2);
+
+    mock.emergency_update(&emergency_owner, EmergencyUpdate::DisallowCoin(osmo_info.denom))
+        .unwrap();
+
+    let allowed_coins_after = mock.query_allowed_coins(None, None);
+    assert_eq!(allowed_coins_after.len(), 1);
+    assert_eq!(allowed_coins_after.first().unwrap(), &atom_info.denom)
+}
+
+#[test]
+fn raises_if_coin_does_not_exist() {
+    let emergency_owner = Addr::unchecked("miles_morales");
+    let osmo_info = uosmo_info();
+
+    let mut mock = MockEnv::new()
+        .emergency_owner(&emergency_owner)
+        .allowed_coins(&[osmo_info])
+        .build()
+        .unwrap();
+
+    let res =
+        mock.emergency_update(&emergency_owner, EmergencyUpdate::DisallowCoin("xyz".to_string()));
+
+    assert_err(
+        res,
+        InvalidConfig {
+            reason: "xyz not in config".to_string(),
+        },
+    )
+}
+
+#[test]
+fn emergency_owner_can_drop_vault_max_ltv() {
+    let emergency_owner = Addr::unchecked("miles_morales");
+    let vault_a = locked_vault_info();
+    let vault_b = unlocked_vault_info();
+
+    let mut mock = MockEnv::new()
+        .emergency_owner(&emergency_owner)
+        .vault_configs(&[vault_a.clone(), vault_b.clone()])
+        .build()
+        .unwrap();
+
+    let vault_a_addr = mock.get_vault(&vault_a);
+    let vault_b_addr = mock.get_vault(&vault_b);
+
+    let vault_a_config_before = mock.query_vault_config(&vault_a_addr);
+    assert!(!vault_a_config_before.config.max_ltv.is_zero());
+    let vault_b_config_before = mock.query_vault_config(&vault_b_addr);
+    assert!(!vault_b_config_before.config.max_ltv.is_zero());
+
+    mock.emergency_update(&emergency_owner, EmergencyUpdate::SetZeroMaxLtv(vault_a_addr.clone()))
+        .unwrap();
+
+    let vault_a_config_after = mock.query_vault_config(&vault_a_addr);
+    assert!(vault_a_config_after.config.max_ltv.is_zero()); // Dropped to zero ✅
+    let vault_b_config_after = mock.query_vault_config(&vault_b_addr);
+    assert!(!vault_b_config_after.config.max_ltv.is_zero());
+}
+
+#[test]
+fn raises_if_vault_does_not_exist_for_max_ltv_drop() {
+    let emergency_owner = Addr::unchecked("miles_morales");
+
+    let mut mock = MockEnv::new().emergency_owner(&emergency_owner).build().unwrap();
+
+    let res = mock.emergency_update(
+        &emergency_owner,
+        EmergencyUpdate::SetZeroMaxLtv(VaultUnchecked::new("vault_addr_123".to_string())),
+    );
+
+    assert_err(
+        res,
+        Std(NotFound {
+            kind: "mars_rover::adapters::vault::config::VaultConfig".to_string(),
+        }),
+    )
+}
+
+#[test]
+fn emergency_owner_can_drop_deposit_cap() {
+    let emergency_owner = Addr::unchecked("miles_morales");
+    let vault_a = locked_vault_info();
+    let vault_b = unlocked_vault_info();
+
+    let mut mock = MockEnv::new()
+        .emergency_owner(&emergency_owner)
+        .vault_configs(&[vault_a.clone(), vault_b.clone()])
+        .build()
+        .unwrap();
+
+    let vault_a_addr = mock.get_vault(&vault_a);
+    let vault_b_addr = mock.get_vault(&vault_b);
+
+    let vault_a_config_before = mock.query_vault_config(&vault_a_addr);
+    assert!(!vault_a_config_before.config.deposit_cap.amount.is_zero());
+    let vault_b_config_before = mock.query_vault_config(&vault_b_addr);
+    assert!(!vault_b_config_before.config.deposit_cap.amount.is_zero());
+
+    mock.emergency_update(
+        &emergency_owner,
+        EmergencyUpdate::SetZeroDepositCap(vault_a_addr.clone()),
+    )
+    .unwrap();
+
+    let vault_a_config_after = mock.query_vault_config(&vault_a_addr);
+    assert!(vault_a_config_after.config.deposit_cap.amount.is_zero()); // Dropped to zero ✅
+    let vault_b_config_after = mock.query_vault_config(&vault_b_addr);
+    assert!(!vault_b_config_after.config.deposit_cap.amount.is_zero());
+}
+
+#[test]
+fn raises_if_vault_does_not_exist_for_deposit_cap_drop() {
+    let emergency_owner = Addr::unchecked("miles_morales");
+
+    let mut mock = MockEnv::new().emergency_owner(&emergency_owner).build().unwrap();
+
+    let res = mock.emergency_update(
+        &emergency_owner,
+        EmergencyUpdate::SetZeroDepositCap(VaultUnchecked::new("vault_addr_123".to_string())),
+    );
+
+    assert_err(
+        res,
+        Std(NotFound {
+            kind: "mars_rover::adapters::vault::config::VaultConfig".to_string(),
+        }),
+    )
+}

--- a/contracts/credit-manager/tests/test_instantiate.rs
+++ b/contracts/credit-manager/tests/test_instantiate.rs
@@ -175,7 +175,7 @@ fn instantiate_raises_on_invalid_vaults_config() {
 fn duplicate_vaults_raises() {
     let mock = MockEnv::new()
         .pre_deployed_vault(&locked_vault_info(), None)
-        .pre_deployed_vault(&unlocked_vault_info(), None)
+        .pre_deployed_vault(&locked_vault_info(), None)
         .build();
     if mock.is_ok() {
         panic!("Should have thrown an error");

--- a/contracts/credit-manager/tests/test_update_admin.rs
+++ b/contracts/credit-manager/tests/test_update_admin.rs
@@ -3,7 +3,7 @@ use mars_owner::{
     OwnerError::{NotOwner, NotProposedOwner, StateTransitionError},
     OwnerUpdate,
 };
-use mars_rover::error::ContractError::OwnerError;
+use mars_rover::error::ContractError::Owner;
 
 use crate::helpers::{assert_err, MockEnv};
 
@@ -33,7 +33,7 @@ fn propose_new_owner() {
             proposed: bad_guy.to_string(),
         },
     );
-    assert_err(res, OwnerError(NotOwner {}));
+    assert_err(res, Owner(NotOwner {}));
 
     mock.update_owner(
         &Addr::unchecked(original_config.owner.clone().unwrap()),
@@ -72,7 +72,7 @@ fn clear_proposed() {
     // only owner can clear
     let bad_guy = Addr::unchecked("bad_guy");
     let res = mock.update_owner(&bad_guy, OwnerUpdate::ClearProposed);
-    assert_err(res, OwnerError(NotOwner {}));
+    assert_err(res, Owner(NotOwner {}));
 
     mock.update_owner(
         &Addr::unchecked(original_config.owner.clone().unwrap()),
@@ -107,7 +107,7 @@ fn accept_owner_role() {
         &Addr::unchecked(original_config.owner.unwrap()),
         OwnerUpdate::AcceptProposed,
     );
-    assert_err(res, OwnerError(NotProposedOwner {}));
+    assert_err(res, Owner(NotProposedOwner {}));
 
     mock.update_owner(&Addr::unchecked(new_owner.clone()), OwnerUpdate::AcceptProposed).unwrap();
 
@@ -125,7 +125,7 @@ fn abolish_owner_role() {
     // Only owner can abolish role
     let bad_guy = Addr::unchecked("bad_guy");
     let res = mock.update_owner(&bad_guy, OwnerUpdate::AbolishOwnerRole);
-    assert_err(res, OwnerError(NotOwner {}));
+    assert_err(res, Owner(NotOwner {}));
 
     mock.update_owner(
         &Addr::unchecked(original_config.owner.clone().unwrap()),
@@ -145,5 +145,5 @@ fn abolish_owner_role() {
             proposed: original_config.owner.unwrap(),
         },
     );
-    assert_err(res, OwnerError(StateTransitionError {}));
+    assert_err(res, Owner(StateTransitionError {}));
 }

--- a/contracts/credit-manager/tests/test_update_nft_config.rs
+++ b/contracts/credit-manager/tests/test_update_nft_config.rs
@@ -25,7 +25,7 @@ fn _only_owner_can_update_config() {
             proposed_new_minter: Some(bad_guy.to_string()),
         },
     );
-    assert_err(res, ContractError::OwnerError(NotOwner {}));
+    assert_err(res, ContractError::Owner(NotOwner {}));
 
     // Attempt updating directly from the NFT contract
     mock.app

--- a/packages/rover/src/error.rs
+++ b/packages/rover/src/error.rs
@@ -26,7 +26,7 @@ pub enum ContractError {
     },
 
     #[error("{0}")]
-    OwnerError(#[from] OwnerError),
+    Owner(#[from] OwnerError),
 
     #[error("{0} is not an available coin to request")]
     CoinNotAvailable(String),
@@ -79,6 +79,9 @@ pub enum ContractError {
         debt_coin: Coin,
         request_coin: Coin,
     },
+
+    #[error("Migration error: {0}")]
+    Migration(String),
 
     #[error("Issued incorrect action for vault type")]
     MismatchedVaultType,

--- a/packages/rover/src/msg/execute.rs
+++ b/packages/rover/src/msg/execute.rs
@@ -31,6 +31,20 @@ pub enum ExecuteMsg {
     UpdateConfig {
         updates: ConfigUpdates,
     },
+    /// Emergency owner has a narrow amount of config changes it is allowed to do:
+    /// - Lower maxLTV of vault to zero
+    /// - Lower deposit cap of vault to zero
+    /// - Remove asset from ALLOWED_COINS list. This has a second order consequence disallowing of that coin:
+    ///     - Borrow
+    ///     - Deposit
+    ///     - Swap into
+    ///     - Zap with/into
+    ///     - Unzap into
+    ///   Coin would still be allowed to:
+    ///     - Withdraw
+    ///     - Swap out of
+    ///     - Repay loan of
+    EmergencyConfigUpdate(EmergencyUpdate),
     /// Manages owner role state
     UpdateOwner(OwnerUpdate),
     /// Update nft contract config
@@ -39,6 +53,13 @@ pub enum ExecuteMsg {
     },
     /// Internal actions only callable by the contract itself
     Callback(CallbackMsg),
+}
+
+#[cw_serde]
+pub enum EmergencyUpdate {
+    SetZeroMaxLtv(VaultUnchecked),
+    SetZeroDepositCap(VaultUnchecked),
+    DisallowCoin(String),
 }
 
 #[cw_serde]

--- a/schemas/mars-credit-manager/mars-credit-manager.json
+++ b/schemas/mars-credit-manager/mars-credit-manager.json
@@ -246,6 +246,19 @@
         "additionalProperties": false
       },
       {
+        "description": "Emergency owner has a narrow amount of config changes it is allowed to do: - Lower maxLTV of vault to zero - Lower deposit cap of vault to zero - Remove asset from ALLOWED_COINS list. This has a second order consequence disallowing of that coin: - Borrow - Deposit - Swap into - Zap with/into - Unzap into Coin would still be allowed to: - Withdraw - Swap out of - Repay loan of",
+        "type": "object",
+        "required": [
+          "emergency_config_update"
+        ],
+        "properties": {
+          "emergency_config_update": {
+            "$ref": "#/definitions/EmergencyUpdate"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Manages owner role state",
         "type": "object",
         "required": [
@@ -1285,6 +1298,46 @@
         "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
         "type": "string"
       },
+      "EmergencyUpdate": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "set_zero_max_ltv"
+            ],
+            "properties": {
+              "set_zero_max_ltv": {
+                "$ref": "#/definitions/VaultBase_for_String"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "set_zero_deposit_cap"
+            ],
+            "properties": {
+              "set_zero_deposit_cap": {
+                "$ref": "#/definitions/VaultBase_for_String"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "disallow_coin"
+            ],
+            "properties": {
+              "disallow_coin": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "Health": {
         "type": "object",
         "required": [
@@ -1419,6 +1472,35 @@
             "type": "string",
             "enum": [
               "abolish_owner_role"
+            ]
+          },
+          {
+            "description": "A separate entity managed by Owner that can be used for granting specific emergency powers.",
+            "type": "object",
+            "required": [
+              "set_emergency_owner"
+            ],
+            "properties": {
+              "set_emergency_owner": {
+                "type": "object",
+                "required": [
+                  "emergency_owner"
+                ],
+                "properties": {
+                  "emergency_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Remove the entity in the Emergency Owner role",
+            "type": "string",
+            "enum": [
+              "clear_emergency_owner"
             ]
           }
         ]

--- a/schemas/mars-swapper-base/mars-swapper-base.json
+++ b/schemas/mars-swapper-base/mars-swapper-base.json
@@ -197,6 +197,35 @@
             "enum": [
               "abolish_owner_role"
             ]
+          },
+          {
+            "description": "A separate entity managed by Owner that can be used for granting specific emergency powers.",
+            "type": "object",
+            "required": [
+              "set_emergency_owner"
+            ],
+            "properties": {
+              "set_emergency_owner": {
+                "type": "object",
+                "required": [
+                  "emergency_owner"
+                ],
+                "properties": {
+                  "emergency_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Remove the entity in the Emergency Owner role",
+            "type": "string",
+            "enum": [
+              "clear_emergency_owner"
+            ]
           }
         ]
       },
@@ -374,6 +403,12 @@
       "properties": {
         "abolished": {
           "type": "boolean"
+        },
+        "emergency_owner": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "initialized": {
           "type": "boolean"

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.client.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.client.ts
@@ -23,6 +23,7 @@ import {
   Action,
   ActionAmount,
   VaultPositionType,
+  EmergencyUpdate,
   OwnerUpdate,
   CallbackMsg,
   Addr,
@@ -327,6 +328,11 @@ export interface MarsCreditManagerInterface extends MarsCreditManagerReadOnlyInt
     memo?: string,
     funds?: Coin[],
   ) => Promise<ExecuteResult>
+  emergencyConfigUpdate: (
+    fee?: number | StdFee | 'auto',
+    memo?: string,
+    funds?: Coin[],
+  ) => Promise<ExecuteResult>
   updateOwner: (
     fee?: number | StdFee | 'auto',
     memo?: string,
@@ -364,6 +370,7 @@ export class MarsCreditManagerClient
     this.createCreditAccount = this.createCreditAccount.bind(this)
     this.updateCreditAccount = this.updateCreditAccount.bind(this)
     this.updateConfig = this.updateConfig.bind(this)
+    this.emergencyConfigUpdate = this.emergencyConfigUpdate.bind(this)
     this.updateOwner = this.updateOwner.bind(this)
     this.updateNftConfig = this.updateNftConfig.bind(this)
     this.callback = this.callback.bind(this)
@@ -428,6 +435,22 @@ export class MarsCreditManagerClient
         update_config: {
           updates,
         },
+      },
+      fee,
+      memo,
+      funds,
+    )
+  }
+  emergencyConfigUpdate = async (
+    fee: number | StdFee | 'auto' = 'auto',
+    memo?: string,
+    funds?: Coin[],
+  ): Promise<ExecuteResult> => {
+    return await this.client.execute(
+      this.sender,
+      this.contractAddress,
+      {
+        emergency_config_update: {},
       },
       fee,
       memo,

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.message-composer.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.message-composer.ts
@@ -24,6 +24,7 @@ import {
   Action,
   ActionAmount,
   VaultPositionType,
+  EmergencyUpdate,
   OwnerUpdate,
   CallbackMsg,
   Addr,
@@ -81,6 +82,7 @@ export interface MarsCreditManagerMessage {
     },
     funds?: Coin[],
   ) => MsgExecuteContractEncodeObject
+  emergencyConfigUpdate: (funds?: Coin[]) => MsgExecuteContractEncodeObject
   updateOwner: (funds?: Coin[]) => MsgExecuteContractEncodeObject
   updateNftConfig: (
     {
@@ -102,6 +104,7 @@ export class MarsCreditManagerMessageComposer implements MarsCreditManagerMessag
     this.createCreditAccount = this.createCreditAccount.bind(this)
     this.updateCreditAccount = this.updateCreditAccount.bind(this)
     this.updateConfig = this.updateConfig.bind(this)
+    this.emergencyConfigUpdate = this.emergencyConfigUpdate.bind(this)
     this.updateOwner = this.updateOwner.bind(this)
     this.updateNftConfig = this.updateNftConfig.bind(this)
     this.callback = this.callback.bind(this)
@@ -167,6 +170,21 @@ export class MarsCreditManagerMessageComposer implements MarsCreditManagerMessag
             update_config: {
               updates,
             },
+          }),
+        ),
+        funds,
+      }),
+    }
+  }
+  emergencyConfigUpdate = (funds?: Coin[]): MsgExecuteContractEncodeObject => {
+    return {
+      typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
+      value: MsgExecuteContract.fromPartial({
+        sender: this.sender,
+        contract: this.contractAddress,
+        msg: toUtf8(
+          JSON.stringify({
+            emergency_config_update: {},
           }),
         ),
         funds,

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.react-query.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.react-query.ts
@@ -24,6 +24,7 @@ import {
   Action,
   ActionAmount,
   VaultPositionType,
+  EmergencyUpdate,
   OwnerUpdate,
   CallbackMsg,
   Addr,
@@ -534,6 +535,26 @@ export function useMarsCreditManagerUpdateOwnerMutation(
 ) {
   return useMutation<ExecuteResult, Error, MarsCreditManagerUpdateOwnerMutation>(
     ({ client, msg, args: { fee, memo, funds } = {} }) => client.updateOwner(msg, fee, memo, funds),
+    options,
+  )
+}
+export interface MarsCreditManagerEmergencyConfigUpdateMutation {
+  client: MarsCreditManagerClient
+  args?: {
+    fee?: number | StdFee | 'auto'
+    memo?: string
+    funds?: Coin[]
+  }
+}
+export function useMarsCreditManagerEmergencyConfigUpdateMutation(
+  options?: Omit<
+    UseMutationOptions<ExecuteResult, Error, MarsCreditManagerEmergencyConfigUpdateMutation>,
+    'mutationFn'
+  >,
+) {
+  return useMutation<ExecuteResult, Error, MarsCreditManagerEmergencyConfigUpdateMutation>(
+    ({ client, msg, args: { fee, memo, funds } = {} }) =>
+      client.emergencyConfigUpdate(msg, fee, memo, funds),
     options,
   )
 }

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
@@ -56,6 +56,9 @@ export type ExecuteMsg =
       }
     }
   | {
+      emergency_config_update: EmergencyUpdate
+    }
+  | {
       update_owner: OwnerUpdate
     }
   | {
@@ -146,6 +149,16 @@ export type ActionAmount =
       exact: Uint128
     }
 export type VaultPositionType = 'u_n_l_o_c_k_e_d' | 'l_o_c_k_e_d' | 'u_n_l_o_c_k_i_n_g'
+export type EmergencyUpdate =
+  | {
+      set_zero_max_ltv: VaultBaseForString
+    }
+  | {
+      set_zero_deposit_cap: VaultBaseForString
+    }
+  | {
+      disallow_coin: string
+    }
 export type OwnerUpdate =
   | {
       propose_new_owner: {
@@ -155,6 +168,12 @@ export type OwnerUpdate =
   | 'clear_proposed'
   | 'accept_proposed'
   | 'abolish_owner_role'
+  | {
+      set_emergency_owner: {
+        emergency_owner: string
+      }
+    }
+  | 'clear_emergency_owner'
 export type CallbackMsg =
   | {
       withdraw: {

--- a/scripts/types/generated/mars-swapper-base/MarsSwapperBase.types.ts
+++ b/scripts/types/generated/mars-swapper-base/MarsSwapperBase.types.ts
@@ -42,6 +42,12 @@ export type OwnerUpdate =
   | 'clear_proposed'
   | 'accept_proposed'
   | 'abolish_owner_role'
+  | {
+      set_emergency_owner: {
+        emergency_owner: string
+      }
+    }
+  | 'clear_emergency_owner'
 export type Uint128 = string
 export type Decimal = string
 export type Addr = string
@@ -80,6 +86,7 @@ export interface EstimateExactInSwapResponse {
 }
 export interface OwnerResponse {
   abolished: boolean
+  emergency_owner?: string | null
   initialized: boolean
   owner?: string | null
   proposed?: string | null


### PR DESCRIPTION
Requires 3 parts:
1. Merge this PR
2. Perform contract migration
3. Issue `SetEmergencyOwner {}` message from current owner

