### PR TITLE
add in red bank to config update 

### DIFF
--- a/contracts/credit-manager/src/update_config.rs
+++ b/contracts/credit-manager/src/update_config.rs
@@ -11,7 +11,7 @@ use crate::{
     instantiate::{assert_lte_to_one, assert_no_duplicate_coins, assert_no_duplicate_vaults},
     state::{
         ACCOUNT_NFT, ALLOWED_COINS, MAX_CLOSE_FACTOR, MAX_UNLOCKING_POSITIONS, ORACLE, OWNER,
-        SWAPPER, VAULT_CONFIGS, ZAPPER,
+        RED_BANK, SWAPPER, VAULT_CONFIGS, ZAPPER,
     },
 };
 
@@ -68,6 +68,12 @@ pub fn update_config(
         ORACLE.save(deps.storage, &unchecked.check(deps.api)?)?;
         response =
             response.add_attribute("key", "oracle").add_attribute("value", unchecked.address());
+    }
+
+    if let Some(unchecked) = updates.red_bank {
+        RED_BANK.save(deps.storage, &unchecked.check(deps.api)?)?;
+        response =
+            response.add_attribute("key", "red_bank").add_attribute("value", unchecked.address());
     }
 
     if let Some(unchecked) = updates.swapper {

--- a/contracts/credit-manager/tests/test_update_config.rs
+++ b/contracts/credit-manager/tests/test_update_config.rs
@@ -1,10 +1,12 @@
 use cosmwasm_std::{coin, Addr, Decimal, Uint128};
 use cw_multi_test::{BasicApp, Executor};
 use mars_mock_oracle::msg::{CoinPrice, InstantiateMsg as OracleInstantiateMsg};
+use mars_mock_red_bank::msg::InstantiateMsg as RedBankInstantiateMsg;
 use mars_mock_vault::msg::InstantiateMsg as VaultInstantiateMsg;
 use mars_rover::{
     adapters::{
         oracle::{OracleBase, OracleUnchecked},
+        red_bank::RedBankUnchecked,
         swap::SwapperBase,
         vault::{VaultBase, VaultConfig},
         zapper::ZapperBase,
@@ -17,8 +19,8 @@ use mars_rover::{
 };
 
 use crate::helpers::{
-    assert_err, locked_vault_info, mock_oracle_contract, mock_vault_contract, uatom_info,
-    uosmo_info, MockEnv,
+    assert_err, locked_vault_info, mock_oracle_contract, mock_red_bank_contract,
+    mock_vault_contract, uatom_info, uosmo_info, MockEnv,
 };
 
 pub mod helpers;
@@ -34,6 +36,7 @@ fn only_owner_can_update_config() {
             account_nft: None,
             allowed_coins: None,
             oracle: None,
+            red_bank: None,
             max_close_factor: None,
             max_unlocking_positions: None,
             swapper: None,
@@ -64,6 +67,7 @@ fn raises_on_invalid_vaults_config() {
             account_nft: None,
             allowed_coins: None,
             oracle: None,
+            red_bank: None,
             max_close_factor: None,
             max_unlocking_positions: None,
             swapper: None,
@@ -90,6 +94,7 @@ fn raises_on_invalid_vaults_config() {
             account_nft: None,
             allowed_coins: None,
             oracle: None,
+            red_bank: None,
             max_close_factor: None,
             max_unlocking_positions: None,
             swapper: None,
@@ -115,6 +120,7 @@ fn raises_on_invalid_vaults_config() {
             account_nft: None,
             allowed_coins: None,
             oracle: None,
+            red_bank: None,
             max_close_factor: None,
             max_unlocking_positions: None,
             swapper: None,
@@ -142,6 +148,7 @@ fn update_config_works_with_full_config() {
     let new_vault_configs = vec![deploy_vault(&mut mock.app)];
     let new_allowed_coins = vec!["uosmo".to_string()];
     let new_oracle = deploy_new_oracle(&mut mock.app);
+    let new_red_bank = deploy_new_red_bank(&mut mock.app);
     let new_zapper = ZapperBase::new("new_zapper".to_string());
     let new_close_factor = Decimal::from_atomics(32u128, 2).unwrap();
     let new_unlocking_max = Uint128::new(321);
@@ -153,6 +160,7 @@ fn update_config_works_with_full_config() {
             account_nft: Some(new_nft_contract.to_string()),
             allowed_coins: Some(new_allowed_coins.clone()),
             oracle: Some(new_oracle.clone()),
+            red_bank: Some(new_red_bank.clone()),
             max_close_factor: Some(new_close_factor),
             max_unlocking_positions: Some(new_unlocking_max),
             swapper: Some(new_swapper.clone()),
@@ -189,6 +197,9 @@ fn update_config_works_with_full_config() {
 
     assert_eq!(&new_config.oracle, new_oracle.address());
     assert_ne!(new_config.oracle, original_config.oracle);
+
+    assert_eq!(&new_config.red_bank, new_red_bank.address());
+    assert_ne!(new_config.red_bank, original_config.red_bank);
 
     assert_eq!(&new_config.zapper, new_zapper.address());
     assert_ne!(new_config.zapper, original_config.zapper);
@@ -340,6 +351,7 @@ fn raises_on_duplicate_vault_configs() {
             account_nft: None,
             allowed_coins: None,
             oracle: None,
+            red_bank: None,
             max_close_factor: None,
             max_unlocking_positions: None,
             swapper: None,
@@ -389,6 +401,7 @@ fn raises_on_duplicate_coin_configs() {
                 "uosmo".to_string(),
             ]),
             oracle: None,
+            red_bank: None,
             max_close_factor: None,
             max_unlocking_positions: None,
             swapper: None,
@@ -429,6 +442,23 @@ fn deploy_new_oracle(app: &mut BasicApp) -> OracleUnchecked {
         )
         .unwrap();
     OracleUnchecked::new(addr.to_string())
+}
+
+fn deploy_new_red_bank(app: &mut BasicApp) -> RedBankUnchecked {
+    let contract_code_id = app.store_code(mock_red_bank_contract());
+    let addr = app
+        .instantiate_contract(
+            contract_code_id,
+            Addr::unchecked("red_bank_contract_owner"),
+            &RedBankInstantiateMsg {
+                coins: vec![],
+            },
+            &[],
+            "mock-red-bank",
+            None,
+        )
+        .unwrap();
+    RedBankUnchecked::new(addr.to_string())
 }
 
 fn deploy_vault(app: &mut BasicApp) -> VaultInstantiateConfig {

--- a/packages/rover/src/msg/instantiate.rs
+++ b/packages/rover/src/msg/instantiate.rs
@@ -69,6 +69,7 @@ pub struct ConfigUpdates {
     pub allowed_coins: Option<Vec<String>>,
     pub vault_configs: Option<Vec<VaultInstantiateConfig>>,
     pub oracle: Option<OracleUnchecked>,
+    pub red_bank: Option<RedBankUnchecked>,
     pub max_close_factor: Option<Decimal>,
     pub max_unlocking_positions: Option<Uint128>,
     pub swapper: Option<SwapperUnchecked>,

--- a/schemas/mars-credit-manager/mars-credit-manager.json
+++ b/schemas/mars-credit-manager/mars-credit-manager.json
@@ -1249,6 +1249,16 @@
               }
             ]
           },
+          "red_bank": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RedBankBase_for_String"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "swapper": {
             "anyOf": [
               {
@@ -1422,6 +1432,9 @@
             ]
           }
         ]
+      },
+      "RedBankBase_for_String": {
+        "type": "string"
       },
       "SwapperBase_for_String": {
         "type": "string"

--- a/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
+++ b/scripts/types/generated/mars-credit-manager/MarsCreditManager.types.ts
@@ -282,6 +282,7 @@ export interface ConfigUpdates {
   max_close_factor?: Decimal | null
   max_unlocking_positions?: Uint128 | null
   oracle?: OracleBaseForString | null
+  red_bank?: RedBankBaseForString | null
   swapper?: SwapperBaseForString | null
   vault_configs?: VaultInstantiateConfig[] | null
   zapper?: ZapperBaseForString | null


### PR DESCRIPTION
These contracts currently do not allow for the red bank contract address to be updated in the credit manager after instantiation. This change adds in red bank to the config update execute msg. 